### PR TITLE
added scrollTo for small screen devices

### DIFF
--- a/app/src/androidTest/java/com/example/lunchtray/BaseTest.kt
+++ b/app/src/androidTest/java/com/example/lunchtray/BaseTest.kt
@@ -18,6 +18,7 @@ package com.example.lunchtray
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.matcher.ViewMatchers.withId
 
 open class BaseTest {

--- a/app/src/androidTest/java/com/example/lunchtray/BaseTest.kt
+++ b/app/src/androidTest/java/com/example/lunchtray/BaseTest.kt
@@ -30,9 +30,9 @@ open class BaseTest {
         // Select entree item
         onView(withId(R.id.cauliflower)).perform(click())
         // Move to next fragment
-        onView(withId(R.id.next_button)).perform(click())
+        onView(withId(R.id.next_button)).perform(scrollTo()).perform(click())
         // Select side item
-        onView(withId(R.id.salad)).perform(click())
+        onView(withId(R.id.salad)).perform(scrollTo()).perform(click())
         // Move to next fragment
         onView(withId(R.id.next_button)).perform(click())
         // Select accompaniment item

--- a/app/src/androidTest/java/com/example/lunchtray/OrderFunctionalityTests.kt
+++ b/app/src/androidTest/java/com/example/lunchtray/OrderFunctionalityTests.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -140,14 +141,14 @@ class OrderFunctionalityTests : BaseTest() {
         // We already have a test for a single menu item selection, so we don't need to check the
         // subtotal here.
         // Move to next fragment
-        onView(withId(R.id.next_button)).perform(click())
+        onView(withId(R.id.next_button)).perform(scrollTo()).perform(click())
         // Select side item
         onView(withId(R.id.salad)).perform(click())
         // Check that subtotal has updated
         onView(withId(R.id.subtotal))
             .check(matches(withText(containsString("Subtotal: $9.50"))))
         // Move to next fragment
-        onView(withId(R.id.next_button)).perform(click())
+        onView(withId(R.id.next_button)).perform(scrollTo()).perform(click())
         // Select accompaniment item
         onView(withId(R.id.bread)).perform(click())
         // Check that subtotal has updated
@@ -191,7 +192,7 @@ class OrderFunctionalityTests : BaseTest() {
         // Select an item
         onView(withId(R.id.cauliflower)).perform(click())
         // Cancel order
-        onView(withId(R.id.cancel_button)).perform(click())
+        onView(withId(R.id.cancel_button)).perform(scrollTo()).perform(click())
         // Start the order
         onView(withId(R.id.start_order_btn)).perform(click())
         // Make sure subtotal is zero
@@ -210,11 +211,11 @@ class OrderFunctionalityTests : BaseTest() {
         // Select an item
         onView(withId(R.id.cauliflower)).perform(click())
         // Move to side menu
-        onView(withId(R.id.next_button)).perform(click())
+        onView(withId(R.id.next_button)).perform(scrollTo()).perform(click())
         // Select an item
         onView(withId(R.id.soup)).perform(click())
         // Cancel the order
-        onView(withId(R.id.cancel_button)).perform(click())
+        onView(withId(R.id.cancel_button)).perform(scrollTo()).perform(click())
         // Start the order
         onView(withId(R.id.start_order_btn)).perform(click())
         // Make sure subtotal is zero
@@ -233,11 +234,11 @@ class OrderFunctionalityTests : BaseTest() {
         // Select an item
         onView(withId(R.id.cauliflower)).perform(click())
         // Move to side menu
-        onView(withId(R.id.next_button)).perform(click())
+        onView(withId(R.id.next_button)).perform(scrollTo()).perform(click())
         // Select an item
         onView(withId(R.id.soup)).perform(click())
         // Move to accompaniment menu
-        onView(withId(R.id.next_button)).perform(click())
+        onView(withId(R.id.next_button)).perform(scrollTo()).perform(click())
         // Select item
         onView(withId(R.id.bread)).perform(click())
         // Cancel the order


### PR DESCRIPTION
Hi, when I run the `OrderFunctionalityTests` and `BaseTest` files I was getting multiple test fails, and this is the error message that I get.


`androidx.test.espresso.PerformException: Error performing 'single click' on view 'view.getId() is <2131231077/com.example.lunchtray:id/next_button>
at com.example.lunchtray.OrderFunctionalityTests.subtotal_updates_in_full_order_flow(OrderFunctionalityTests.kt:144)
... 27 trimmed
Caused by: java.lang.RuntimeException: Action will not be performed because the target view does not match one or more of the following constraints:
(view has effective visibility <VISIBLE> and view.getGlobalVisibleRect() covers at least <90> percent of the view's area)
Target view: "MaterialButton{id=2131231077, res-name=next_button, visibility=VISIBLE, width=468, height=144, has-focus=false, has-focusable=true, has-window-focus=true, is-clickable=true, is-enabled=true, is-focused=false, is-focusable=true, is-layout-requested=false, is-selected=false, layout-params=androidx.constraintlayout.widget.ConstraintLayout$LayoutParams@94f1dd6, tag=null, root-is-layout-requested=false, has-input-connection=false, x=564.0, y=1650.0, text=Next, input-type=0, ime-target=false, has-links=false, is-checked=false}`

It was because the screen device that I run the test on the `next_button` and `cancel_button` was not visible in the test, so I had to add a `scrollTo` to each of the `next_button` and `cancel_button` for the test to pass.

The device that I run the test on was:
Name: Huawei P9
OS Version: 24
Screen size: 5.2
Smallest width: 360dp

<img width="200" alt="Screenshot_20220915-094744444" src="https://user-images.githubusercontent.com/85061997/190343317-d40d58d5-3b7e-40c4-8b6a-ff605a0045c9.png">
