### PR TITLE
Updates for NavigationTests and OrderFunctionalityTests

### DIFF
--- a/app/src/androidTest/java/com/example/lunchtray/NavigationTests.kt
+++ b/app/src/androidTest/java/com/example/lunchtray/NavigationTests.kt
@@ -80,7 +80,7 @@ class NavigationTests : BaseTest() {
         // Click the cancel button
         onView(withId(R.id.cancel_button)).perform(click())
         // Check that the destination is correct
-        assertEquals(navController.currentDestination?.id, R.id.startOrder)
+        assertEquals(navController.currentDestination?.id, R.id.startOrderFragment)
     }
 
     /**
@@ -123,7 +123,7 @@ class NavigationTests : BaseTest() {
             Navigation.setViewNavController(fragment.requireView(), navController)
         }
         onView(withId(R.id.cancel_button)).perform(click())
-        assertEquals(navController.currentDestination?.id, R.id.startOrder)
+        assertEquals(navController.currentDestination?.id, R.id.startOrderFragment)
     }
 
     /**
@@ -160,7 +160,7 @@ class NavigationTests : BaseTest() {
             Navigation.setViewNavController(fragment.requireView(), navController)
         }
         onView(withId(R.id.cancel_button)).perform(click())
-        assertEquals(navController.currentDestination?.id, R.id.startOrder)
+        assertEquals(navController.currentDestination?.id, R.id.startOrderFragment)
     }
 
     /**
@@ -197,7 +197,7 @@ class NavigationTests : BaseTest() {
             Navigation.setViewNavController(fragment.requireView(), navController)
         }
         onView(withId(R.id.cancel_button)).perform(click())
-        assertEquals(navController.currentDestination?.id, R.id.startOrder)
+        assertEquals(navController.currentDestination?.id, R.id.startOrderFragment)
     }
 
     /**
@@ -215,6 +215,6 @@ class NavigationTests : BaseTest() {
             Navigation.setViewNavController(fragment.requireView(), navController)
         }
         onView(withId(R.id.submit_button)).perform(click())
-        assertEquals(navController.currentDestination?.id, R.id.startOrder)
+        assertEquals(navController.currentDestination?.id, R.id.startOrderFragment)
     }
 }

--- a/app/src/androidTest/java/com/example/lunchtray/OrderFunctionalityTests.kt
+++ b/app/src/androidTest/java/com/example/lunchtray/OrderFunctionalityTests.kt
@@ -107,20 +107,20 @@ class OrderFunctionalityTests : BaseTest() {
      */
     @Test
     fun `radio_buttons_update_accompaniment_menu_subtotal`() {
-        // Launch the side menu fragment
+        // Launch the accompaniment menu fragment
         launchFragmentInContainer<AccompanimentMenuFragment>(themeResId = R.style.Theme_LunchTray)
 
-        // Select the salad item
+        // Select the bread item
         onView(withId(R.id.bread)).perform(click())
         onView(withId(R.id.subtotal))
             .check(matches(withText(containsString("Subtotal: $0.50"))))
 
-        // Select the soup item
+        // Select the berries item
         onView(withId(R.id.berries)).perform(click())
         onView(withId(R.id.subtotal))
             .check(matches(withText(containsString("Subtotal: $1.00"))))
 
-        // Select the potato item
+        // Select the pickles item
         onView(withId(R.id.pickles)).perform(click())
         onView(withId(R.id.subtotal))
             .check(matches(withText(containsString("Subtotal: $0.50"))))


### PR DESCRIPTION
I have updated two of the test files with following changes:

1. NavigationTests.kt
- The test functions that start with fun 'navigate_to_start_order_from....' have been updated to include the correct Fragment destination. Following the click of the cancel or submit button, I believe it should navigate to startOrderFragment.

2. OrderFunctionalityTests.kt
- The AccompanimentMenuFragment subtotal test section comments have been updated, I believe they had been accidental duplicates of the SideMenuFragment subtotal test section (starting line 70).

Please let me know if there are any questions - thanks!